### PR TITLE
fix(ui): Select dropdowns render behind modals

### DIFF
--- a/apps/frontend/src/components/ui/select.tsx
+++ b/apps/frontend/src/components/ui/select.tsx
@@ -69,7 +69,7 @@ const SelectContent = React.forwardRef<
 		<SelectPrimitive.Content
 			ref={ref}
 			className={cn(
-				'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+				'relative z-[120] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 				position === 'popper' &&
 					'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
 				className,


### PR DESCRIPTION
## Summary
- Select dropdowns (`z-50`) were rendered behind Dialog overlays/content (`z-[110]`), making them unclickable inside modals
- Increased `SelectContent` z-index to `z-[120]` so dropdowns render above modals

## Affected areas
- Template Creator dropdown (#363)
- Bulk Export format selection (#362)
- API Key expiration date picker (#361)

## Fix
Single-line change in `apps/frontend/src/components/ui/select.tsx` — `z-50` → `z-[120]`

Fixes #361, fixes #362, fixes #363

## Test plan
- [x] Open Template Creator modal → verify Select dropdowns are clickable
- [x] Open Bulk Export dialog → verify format dropdown works
- [x] Open Create API Key dialog → verify expiration dropdown works
- [x] Verify Select dropdowns outside of modals still work correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Fixed the layering of select dropdown menus to ensure they display properly above other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->