### PR TITLE
feat(storage): serve assets via public CDN URL (Cloudflare R2 prep)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -118,8 +118,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build shared package
-        run: pnpm --filter @shared/schemas build
+      - name: Build shared packages
+        run: pnpm run build:shared-packages
 
       - name: Start MinIO and create bucket
         run: |

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -63,6 +63,7 @@ jobs:
       S3_UPLOAD_KEY: 'minio'
       S3_UPLOAD_SECRET: 'testtest1'
       S3_BUCKET_NAME: 'qrcodly'
+      S3_PUBLIC_URL: 'http://127.0.0.1:9000/qrcodly'
 
       # App config
       BACKEND_URL: 'http://localhost:5001'
@@ -137,6 +138,7 @@ jobs:
           chmod +x /usr/local/bin/mc
           mc alias set ci http://127.0.0.1:9000 minio testtest1
           mc mb ci/qrcodly --ignore-existing
+          mc anonymous set download ci/qrcodly
 
       - name: Run Checks
         working-directory: apps/backend

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -24,6 +24,7 @@ S3_REGION="eu-west"
 S3_UPLOAD_KEY=""
 S3_UPLOAD_SECRET=""
 S3_BUCKET_NAME="qrcodly"
+S3_PUBLIC_URL="http://localhost:9000/qrcodly"
 
 TZ="Europe/Berlin"
 

--- a/apps/backend/src/core/config/env.ts
+++ b/apps/backend/src/core/config/env.ts
@@ -36,6 +36,7 @@ const server = z.object({
 	S3_UPLOAD_KEY: z.string(),
 	S3_UPLOAD_SECRET: z.string(),
 	S3_BUCKET_NAME: z.string(),
+	S3_PUBLIC_URL: z.url(),
 	SENTRY_DSN: z.url(),
 	SENTRY_ENVIRONMENT: z.enum(['development', 'production']).default('production'),
 	AXIOM_DATASET: z.string().optional(),

--- a/apps/backend/src/core/domain/strategies/base-image.strategy.ts
+++ b/apps/backend/src/core/domain/strategies/base-image.strategy.ts
@@ -62,6 +62,10 @@ export abstract class BaseImageStrategy {
 		}
 	}
 
+	getPublicUrl(imagePath: string): string {
+		return this.objectStorage.getPublicUrl(imagePath);
+	}
+
 	async getSignedUrl(imagePath: string): Promise<string | undefined> {
 		try {
 			return await this.objectStorage.getSignedUrl(imagePath, this.signedUrlExpirySeconds);

--- a/apps/backend/src/core/interface/file-storage.interface.ts
+++ b/apps/backend/src/core/interface/file-storage.interface.ts
@@ -29,4 +29,13 @@ export interface IFileStorage {
 	 * @returns A signed URL string.
 	 */
 	getSignedUrl(key: string, expiresIn?: number): Promise<string>;
+
+	/**
+	 * Build the public CDN URL for a key. Assumes the bucket is fronted by a
+	 * public custom domain (e.g. cdn.qrcodly.de) and the key filename carries
+	 * enough entropy to be unguessable.
+	 * @param key The file path or key.
+	 * @returns The public URL string.
+	 */
+	getPublicUrl(key: string): string;
 }

--- a/apps/backend/src/core/services/image.service.ts
+++ b/apps/backend/src/core/services/image.service.ts
@@ -41,6 +41,10 @@ export class ImageService {
 		return this.strategy.getSignedUrl(imagePath);
 	}
 
+	getPublicUrl(imagePath: string): string {
+		return this.strategy.getPublicUrl(imagePath);
+	}
+
 	constructFilePath(folder: string, userId: string | undefined, fileName: string): string {
 		return this.strategy.constructFilePath(folder, userId, fileName);
 	}

--- a/apps/backend/src/core/storage/object.storage.ts
+++ b/apps/backend/src/core/storage/object.storage.ts
@@ -165,6 +165,12 @@ export class ObjectStorage implements IFileStorage {
 		if (listedObjects.IsTruncated) await this.emptyS3Directory(dir);
 	}
 
+	getPublicUrl(key: string): string {
+		const k = this.prefix + key;
+		const base = env.S3_PUBLIC_URL.replace(/\/$/, '');
+		return `${base}/${k}`;
+	}
+
 	async getSignedUrl(
 		key: string,
 		expiresIn: number | undefined = DEFAULT_PUBLIC_LINK_LIFETIME,

--- a/apps/backend/src/modules/config-template/useCase/__tests__/get-config-template.use-case.test.ts
+++ b/apps/backend/src/modules/config-template/useCase/__tests__/get-config-template.use-case.test.ts
@@ -41,9 +41,7 @@ describe('GetConfigTemplateUseCase', () => {
 		mockRepository.findOneById.mockImplementation(async () =>
 			JSON.parse(JSON.stringify(mockTemplate)),
 		);
-		mockImageService.getSignedUrl.mockImplementation(async (path) => {
-			if (!path) return undefined;
-			// Extract filename from s3:// path
+		mockImageService.getPublicUrl.mockImplementation((path) => {
 			const filename = path.replace('s3://bucket/', '');
 			return `https://cdn.example.com/${filename}`;
 		});
@@ -75,21 +73,21 @@ describe('GetConfigTemplateUseCase', () => {
 		it('should convert config image to signed URL when convertImagePathToUrl is true', async () => {
 			const result = await useCase.execute('template-123', true);
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/config-image.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/config-image.png');
 			expect(result?.config.image).toContain('https://cdn.example.com/');
 		});
 
 		it('should convert preview image to signed URL when convertImagePathToUrl is true', async () => {
 			const result = await useCase.execute('template-123', true);
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/preview.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/preview.png');
 			expect(result?.previewImage).toContain('https://cdn.example.com/');
 		});
 
 		it('should not convert images when convertImagePathToUrl is false', async () => {
 			const result = await useCase.execute('template-123', false);
 
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalled();
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalled();
 			expect(result?.config.image).toBe('s3://bucket/config-image.png');
 			expect(result?.previewImage).toBe('s3://bucket/preview.png');
 		});
@@ -97,7 +95,7 @@ describe('GetConfigTemplateUseCase', () => {
 		it('should not convert images when convertImagePathToUrl is not provided', async () => {
 			const result = await useCase.execute('template-123');
 
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalled();
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalled();
 			expect(result?.config.image).toBe('s3://bucket/config-image.png');
 		});
 
@@ -125,15 +123,6 @@ describe('GetConfigTemplateUseCase', () => {
 			};
 
 			mockRepository.findOneById.mockResolvedValue(templateWithoutPreview);
-
-			const result = await useCase.execute('template-123', true);
-
-			expect(result?.previewImage).toBeNull();
-		});
-
-		it('should return null preview when signed URL is null', async () => {
-			// @ts-ignore expecting this to test null behavior
-			mockImageService.getSignedUrl.mockResolvedValue(null);
 
 			const result = await useCase.execute('template-123', true);
 

--- a/apps/backend/src/modules/config-template/useCase/__tests__/list-config-templates.use-case.test.ts
+++ b/apps/backend/src/modules/config-template/useCase/__tests__/list-config-templates.use-case.test.ts
@@ -55,9 +55,7 @@ describe('ListConfigTemplatesUseCase', () => {
 			JSON.parse(JSON.stringify(mockTemplates)),
 		);
 		mockRepository.countTotal.mockResolvedValue(2);
-		mockImageService.getSignedUrl.mockImplementation(async (path) => {
-			if (!path) return undefined;
-			// Extract filename from s3:// path
+		mockImageService.getPublicUrl.mockImplementation((path) => {
 			const filename = path.replace('s3://bucket/', '');
 			return `https://cdn.example.com/${filename}`;
 		});
@@ -92,7 +90,7 @@ describe('ListConfigTemplatesUseCase', () => {
 				page: 1,
 			});
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/image1.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/image1.png');
 		});
 
 		it('should convert preview image paths to signed URLs', async () => {
@@ -101,7 +99,7 @@ describe('ListConfigTemplatesUseCase', () => {
 				page: 1,
 			});
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/preview1.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/preview1.png');
 		});
 
 		it('should not attempt to convert null preview images', async () => {
@@ -120,7 +118,7 @@ describe('ListConfigTemplatesUseCase', () => {
 			});
 
 			// Should only be called for config.image, not previewImage
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalledWith(null);
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalledWith(null);
 		});
 
 		it('should count total config templates', async () => {
@@ -189,7 +187,7 @@ describe('ListConfigTemplatesUseCase', () => {
 			});
 
 			// All images should be processed
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledTimes(20); // 10 config images + 10 preview images
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledTimes(20); // 10 config images + 10 preview images
 		});
 
 		it('should convert images to signed URLs in results', async () => {
@@ -222,19 +220,7 @@ describe('ListConfigTemplatesUseCase', () => {
 			});
 
 			// Should complete without errors
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalledWith(null);
-		});
-
-		it('should return null preview image when signed URL is null', async () => {
-			// @ts-ignore expecting this to test null behavior
-			mockImageService.getSignedUrl.mockResolvedValue(null);
-
-			const result = await useCase.execute({
-				limit: 10,
-				page: 1,
-			});
-
-			expect(result.configTemplates[0].previewImage).toBeNull();
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalledWith(null);
 		});
 
 		it('should filter by isPredefined', async () => {

--- a/apps/backend/src/modules/config-template/useCase/get-config-template.use-case.ts
+++ b/apps/backend/src/modules/config-template/useCase/get-config-template.use-case.ts
@@ -36,16 +36,12 @@ export class GetConfigTemplateUseCase implements IBaseUseCase {
 			return null;
 		}
 
-		// Optionally replace stored image paths with presigned URLs for client access.
 		if (convertImagePathToUrl) {
 			if (configTemplate.config.image) {
-				configTemplate.config.image = await this.imageService.getSignedUrl(
-					configTemplate.config.image,
-				);
+				configTemplate.config.image = this.imageService.getPublicUrl(configTemplate.config.image);
 			}
 			if (configTemplate.previewImage) {
-				configTemplate.previewImage =
-					(await this.imageService.getSignedUrl(configTemplate.previewImage)) ?? null;
+				configTemplate.previewImage = this.imageService.getPublicUrl(configTemplate.previewImage);
 			}
 		}
 

--- a/apps/backend/src/modules/config-template/useCase/list-config-templates.use-case.ts
+++ b/apps/backend/src/modules/config-template/useCase/list-config-templates.use-case.ts
@@ -33,20 +33,14 @@ export class ListConfigTemplatesUseCase implements IBaseUseCase {
 			where,
 		});
 
-		// Convert image path to presigned URL
-		await Promise.all(
-			configTemplates.map(async (configTemplate) => {
-				if (configTemplate.config.image) {
-					configTemplate.config.image = await this.imageService.getSignedUrl(
-						configTemplate.config.image,
-					);
-				}
-				if (configTemplate.previewImage) {
-					configTemplate.previewImage =
-						(await this.imageService.getSignedUrl(configTemplate.previewImage)) ?? null;
-				}
-			}),
-		);
+		for (const configTemplate of configTemplates) {
+			if (configTemplate.config.image) {
+				configTemplate.config.image = this.imageService.getPublicUrl(configTemplate.config.image);
+			}
+			if (configTemplate.previewImage) {
+				configTemplate.previewImage = this.imageService.getPublicUrl(configTemplate.previewImage);
+			}
+		}
 
 		// Count the total number of Config Templates
 		const total = await this.configTemplateRepository.countTotal(where);

--- a/apps/backend/src/modules/qr-code/http/controller/qr-code.controller.ts
+++ b/apps/backend/src/modules/qr-code/http/controller/qr-code.controller.ts
@@ -181,18 +181,12 @@ export class QrCodeController extends AbstractController {
 	): Promise<IHttpResponse<TQrCodeWithRelationsResponseDto>> {
 		const qrCode = await this.fetchOwnedQrCode(request.params.id, request.user.id);
 
-		await Promise.all([
-			(async () => {
-				if (qrCode.config.image) {
-					qrCode.config.image = await this.imageService.getSignedUrl(qrCode.config.image);
-				}
-			})(),
-			(async () => {
-				if (qrCode.previewImage) {
-					qrCode.previewImage = (await this.imageService.getSignedUrl(qrCode.previewImage)) ?? null;
-				}
-			})(),
-		]);
+		if (qrCode.config.image) {
+			qrCode.config.image = this.imageService.getPublicUrl(qrCode.config.image);
+		}
+		if (qrCode.previewImage) {
+			qrCode.previewImage = this.imageService.getPublicUrl(qrCode.previewImage);
+		}
 
 		return this.makeApiHttpResponse(200, QrCodeWithRelationsResponseDto.parse(qrCode));
 	}

--- a/apps/backend/src/modules/qr-code/useCase/__tests__/get-public-shared-qr-code.use-case.test.ts
+++ b/apps/backend/src/modules/qr-code/useCase/__tests__/get-public-shared-qr-code.use-case.test.ts
@@ -52,7 +52,7 @@ describe('GetPublicSharedQrCodeUseCase', () => {
 		useCase = new GetPublicSharedQrCodeUseCase(mockRepository, mockImageService, mockLogger);
 
 		mockRepository.findByShareToken.mockResolvedValue(mockShareWithQrCode);
-		mockImageService.getSignedUrl.mockResolvedValue('https://signed-url.example.com/image.png');
+		mockImageService.getPublicUrl.mockReturnValue('https://cdn.example.com/image.png');
 	});
 
 	afterEach(() => {
@@ -118,8 +118,8 @@ describe('GetPublicSharedQrCodeUseCase', () => {
 
 		const result = await useCase.execute('share-token-abc');
 
-		expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/preview.png');
-		expect(result.previewImage).toBe('https://signed-url.example.com/image.png');
+		expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/preview.png');
+		expect(result.previewImage).toBe('https://cdn.example.com/image.png');
 	});
 
 	it('should return null previewImage when no preview exists', async () => {

--- a/apps/backend/src/modules/qr-code/useCase/__tests__/list-qr-code.use-case.test.ts
+++ b/apps/backend/src/modules/qr-code/useCase/__tests__/list-qr-code.use-case.test.ts
@@ -64,9 +64,7 @@ describe('ListQrCodesUseCase', () => {
 		// Return fresh copies to avoid mutation issues
 		mockRepository.findAll.mockImplementation(async () => JSON.parse(JSON.stringify(mockQrCodes)));
 		mockRepository.countTotal.mockResolvedValue(2);
-		mockImageService.getSignedUrl.mockImplementation(async (path) => {
-			if (!path) return undefined;
-			// Extract filename from s3:// path
+		mockImageService.getPublicUrl.mockImplementation((path) => {
 			const filename = path.replace('s3://bucket/', '');
 			return `https://cdn.example.com/${filename}`;
 		});
@@ -103,7 +101,7 @@ describe('ListQrCodesUseCase', () => {
 				page: 1,
 			});
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/image1.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/image1.png');
 		});
 
 		it('should convert preview image paths to signed URLs', async () => {
@@ -112,7 +110,7 @@ describe('ListQrCodesUseCase', () => {
 				page: 1,
 			});
 
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledWith('s3://bucket/preview1.png');
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledWith('s3://bucket/preview1.png');
 		});
 
 		it('should not attempt to convert null preview images', async () => {
@@ -131,7 +129,7 @@ describe('ListQrCodesUseCase', () => {
 			});
 
 			// Should only be called for config.image, not previewImage
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalledWith(null);
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalledWith(null);
 		});
 
 		it('should count total QR codes', async () => {
@@ -206,7 +204,7 @@ describe('ListQrCodesUseCase', () => {
 			});
 
 			// All images should be processed
-			expect(mockImageService.getSignedUrl).toHaveBeenCalledTimes(20); // 10 config images + 10 preview images
+			expect(mockImageService.getPublicUrl).toHaveBeenCalledTimes(20); // 10 config images + 10 preview images
 		});
 
 		it('should handle null image gracefully', async () => {
@@ -229,19 +227,7 @@ describe('ListQrCodesUseCase', () => {
 			});
 
 			// Should complete without errors
-			expect(mockImageService.getSignedUrl).not.toHaveBeenCalledWith(null);
-		});
-
-		it('should return null preview image when signed URL is null', async () => {
-			// @ts-expect-error to test null behavior
-			mockImageService.getSignedUrl.mockResolvedValue(null);
-
-			const result = await useCase.execute({
-				limit: 10,
-				page: 1,
-			});
-
-			expect(result.qrCodes[0].previewImage).toBeNull();
+			expect(mockImageService.getPublicUrl).not.toHaveBeenCalledWith(null);
 		});
 
 		it('should pass contentType filter to repository', async () => {

--- a/apps/backend/src/modules/qr-code/useCase/get-public-shared-qr-code.use-case.ts
+++ b/apps/backend/src/modules/qr-code/useCase/get-public-shared-qr-code.use-case.ts
@@ -35,14 +35,13 @@ export class GetPublicSharedQrCodeUseCase implements IBaseUseCase {
 			throw new QrCodeShareNotFoundError();
 		}
 
-		// Convert S3 image paths to presigned URLs
 		if (qrCode.config.image) {
-			qrCode.config.image = await this.imageService.getSignedUrl(qrCode.config.image);
+			qrCode.config.image = this.imageService.getPublicUrl(qrCode.config.image);
 		}
 
 		let previewImage = qrCode.previewImage;
 		if (previewImage) {
-			previewImage = (await this.imageService.getSignedUrl(previewImage)) ?? null;
+			previewImage = this.imageService.getPublicUrl(previewImage);
 		}
 
 		this.logger.debug('qrCodeShare.publicAccess', {

--- a/apps/backend/src/modules/qr-code/useCase/list-qr-code.use-case.ts
+++ b/apps/backend/src/modules/qr-code/useCase/list-qr-code.use-case.ts
@@ -44,17 +44,14 @@ export class ListQrCodesUseCase implements IBaseUseCase {
 			tagIds,
 		});
 
-		// Convert image path to presigned URL
-		await Promise.all(
-			qrCodes.map(async (qrCode) => {
-				if (qrCode.config.image) {
-					qrCode.config.image = await this.imageService.getSignedUrl(qrCode.config.image);
-				}
-				if (qrCode.previewImage) {
-					qrCode.previewImage = (await this.imageService.getSignedUrl(qrCode.previewImage)) ?? null;
-				}
-			}),
-		);
+		for (const qrCode of qrCodes) {
+			if (qrCode.config.image) {
+				qrCode.config.image = this.imageService.getPublicUrl(qrCode.config.image);
+			}
+			if (qrCode.previewImage) {
+				qrCode.previewImage = this.imageService.getPublicUrl(qrCode.previewImage);
+			}
+		}
 
 		// Count the total number of QR codes
 		const total = await this.qrCodeRepository.countTotal(where, contentType, tagIds);

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -82,7 +82,12 @@ const config = {
 			},
 			{
 				protocol: 'https',
-				hostname: 's3.fr-par.scw.cloud',
+				hostname: 'cdn.qrcodly.de',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'cdn-stage.qrcodly.de',
 				pathname: '/**',
 			},
 		],

--- a/apps/frontend/src/components/dashboard/qrCode/QrCodePreviewCell.tsx
+++ b/apps/frontend/src/components/dashboard/qrCode/QrCodePreviewCell.tsx
@@ -19,7 +19,6 @@ export const QrCodePreviewCell = ({ qr }: { qr: TQrCodeWithRelationsResponseDto 
 									alt="QR code preview"
 									className="size-14 object-cover"
 									loading="lazy"
-									unoptimized
 								/>
 							) : (
 								<DynamicQrCode qrCode={qr} additionalStyles="max-h-14 max-w-14" />
@@ -36,7 +35,6 @@ export const QrCodePreviewCell = ({ qr }: { qr: TQrCodeWithRelationsResponseDto 
 								height={200}
 								alt="QR code preview"
 								className="h-[200px] w-[200px] object-cover"
-								unoptimized
 							/>
 						) : (
 							<DynamicQrCode qrCode={qr} additionalStyles="max-h-[200px] max-w-[200px]" />

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,20 @@ services:
       - 9001:9001
     command: server /data --console-address ":9001"
 
+  minio-setup:
+    container_name: qrcodly-minio-setup
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    restart: 'no'
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set local http://minio:9000 minio testtest) do sleep 1; done;
+      /usr/bin/mc mb --ignore-existing local/qrcodly;
+      /usr/bin/mc anonymous set download local/qrcodly;
+      exit 0;
+      "
+
 volumes:
   database:
   minio-data:


### PR DESCRIPTION
## Summary
- Switch image previews and user uploads from on-demand S3 pre-signed URLs to stable public CDN URLs
- Prep for migration from Scaleway S3 to Cloudflare R2 fronted by `cdn.qrcodly.de` / `cdn-stage.qrcodly.de`
- Adds required `S3_PUBLIC_URL` env var; keeps `getSignedUrl()` on the storage layer for future private-asset flows

## Why
- Stable URLs = browser cache works (URLs no longer change every hour)
- R2 custom domain = CDN edge caching, zero egress, cleaner branded URLs
- UUID-v4 filenames + R2's lack of `ListBucket` on the public custom domain keep files enumeration-safe even though the bucket is public

## Changes
- **Backend**: `ObjectStorage.getPublicUrl()`, threaded through `BaseImageStrategy` + `ImageService`; 5 read-path use cases / controller now return public URLs synchronously (no more `Promise.all` around signing)
- **Local / CI**: MinIO bucket set to `anonymous download` so `S3_PUBLIC_URL=http://localhost:9000/qrcodly` serves directly; docker-compose gains a `minio-setup` bootstrap service
- **Frontend**: `next.config.mjs` `remotePatterns` whitelists `cdn.qrcodly.de` + `cdn-stage.qrcodly.de`, drops the legacy `s3.fr-par.scw.cloud` entry
- DB stores bare keys (provider-agnostic) → **no data migration needed on the app side**; only bucket contents need to be `rclone`d

## Deploy steps (not in this PR)
1. Create R2 buckets `qrcodly-prod` / `qrcodly-stage` + custom domains + API tokens (Cloudflare dashboard)
2. `rclone sync` Scaleway → R2
3. Set `S3_ENDPOINT`, `S3_REGION=auto`, `S3_UPLOAD_KEY/SECRET`, `S3_BUCKET_NAME`, `S3_PUBLIC_URL` in Coolify env for stage → deploy → smoke-test → prod
4. Keep Scaleway read-only for 7 days as rollback net

## Test plan
- [x] `pnpm run pr:precheck` (lint + typecheck + 1465 backend tests + build) — green locally
- [ ] CI `backend-test.yml` green
- [ ] After deploy: `curl -I https://cdn.qrcodly.de/qr-codes/images/previews/<userId>/<uuid>.svg` → 200, correct `content-type`
- [ ] Dashboard: QR preview `<img>` URLs are `cdn.qrcodly.de/...` without `X-Amz-Signature` query params
- [ ] Upload a new logo → appears under CDN URL
- [ ] Re-run `find-orphaned-s3-images.ts` against R2 → clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for public CDN URLs for QR code and config template images, replacing presigned URL generation.
  * Implemented dedicated CDN hosts (`cdn.qrcodly.de` for production and `cdn-stage.qrcodly.de` for staging) for improved image delivery and caching.

* **Configuration**
  * Enabled anonymous read access for image storage, streamlining public image retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->