### PR TITLE
fix(storage): cache-bust preview filenames with timestamp

### DIFF
--- a/apps/backend/src/modules/config-template/domain/strategies/config-template-image.strategy.ts
+++ b/apps/backend/src/modules/config-template/domain/strategies/config-template-image.strategy.ts
@@ -50,7 +50,7 @@ export class ConfigTemplateImageStrategy extends BaseImageStrategy {
 		const { id, createdBy, config } = ConfigTemplate;
 
 		try {
-			const fileName = `${id}.svg`;
+			const fileName = `${id}-${Date.now()}.svg`;
 			const filePath = this.constructFilePath(
 				QR_CODE_TEMPLATE_PREVIEW_IMAGE_FOLDER,
 				createdBy ?? undefined,

--- a/apps/backend/src/modules/qr-code/domain/strategies/qr-code-image.strategy.ts
+++ b/apps/backend/src/modules/qr-code/domain/strategies/qr-code-image.strategy.ts
@@ -57,7 +57,7 @@ export class QrCodeImageStrategy extends BaseImageStrategy {
 		}
 
 		try {
-			const fileName = `${id}.svg`;
+			const fileName = `${id}-${Date.now()}.svg`;
 			const filePath = this.constructFilePath(
 				QR_CODE_PREVIEW_IMAGE_FOLDER,
 				createdBy ?? undefined,


### PR DESCRIPTION
## Summary
- QR-Code / Template-Previews werden beim Update unter exakt gleichem Key `qr-codes/images/previews/<userId>/<id>.svg` neu hochgeladen → Public-URL ändert sich nie → Cloudflare Edge (1y TTL) + Browser servieren weiter das alte Bild
- Fix: Filename ist jetzt `<id>-<timestamp>.svg`, jeder Regenerate erzeugt einen neuen Key + neue URL → sauberer Cache-Miss auf allen Layern
- Alte Preview wird weiterhin vorher im Update-Use-Case gelöscht, also keine neuen Orphans

## Betroffene Dateien
- `apps/backend/src/modules/qr-code/domain/strategies/qr-code-image.strategy.ts`
- `apps/backend/src/modules/config-template/domain/strategies/config-template-image.strategy.ts`

## Test plan
- [x] `pnpm run typecheck` — grün
- [ ] CI (backend-test.yml)
- [ ] Manual: QR-Code bearbeiten → Preview aktualisiert sich ohne Hard-Refresh
- [ ] Manual: Template bearbeiten → dito

🤖 Generated with [Claude Code](https://claude.com/claude-code)