### PR TITLE
fix(frontend): stabilize google maps loader across locale changes

### DIFF
--- a/apps/frontend/src/components/qr-generator/content/LocationSection.tsx
+++ b/apps/frontend/src/components/qr-generator/content/LocationSection.tsx
@@ -15,7 +15,7 @@ import { InputGroup, InputGroupInput, InputGroupAddon } from '@/components/ui/in
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { useEffect, useState } from 'react';
 import { LocationInputSchema, objDiff, type TLocationInput } from '@shared/schemas/src';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { StandaloneSearchBox, useJsApiLoader, type Libraries } from '@react-google-maps/api';
 import { Loader2 } from 'lucide-react';
@@ -31,7 +31,6 @@ const GOOGLE_MAPS_LIBRARIES: Libraries = ['places'];
 
 const LocationSectionBase = ({ onChange, value }: LocationSectionProps) => {
 	const t = useTranslations('generator.contentSwitch.location');
-	const locale = useLocale();
 
 	const form = useForm<TLocationInput>({
 		resolver: zodResolver(LocationInputSchema),
@@ -68,7 +67,6 @@ const LocationSectionBase = ({ onChange, value }: LocationSectionProps) => {
 		id: 'google-maps-script',
 		googleMapsApiKey: env.NEXT_PUBLIC_GOOGLE_API_KEY,
 		libraries: GOOGLE_MAPS_LIBRARIES,
-		language: locale,
 	});
 
 	const handlePlacesChanged = () => {


### PR DESCRIPTION
## Summary
- Remove dynamic `language: locale` from `useJsApiLoader` in `LocationSection.tsx`
- Google Maps' `Loader` is a global singleton — re-calling it with different options (e.g. `es` → `en` on locale switch) throws `Loader must not be called again with different options` and crashes the location generator
- Places results now use Google's default browser-language behavior, which stays stable across client-side locale changes

Fixes [QRCODLY-5D](https://fb-development.sentry.io/issues/QRCODLY-5D) (2 events, production)

## Test plan
- [ ] Open QR generator → Location content type on `/de`
- [ ] Switch locale to `/en` via the language switcher without reload
- [ ] Confirm the Places search box still loads and no Sentry error is thrown
- [ ] Verify place selection still populates address / lat / lng

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Google Maps integration configuration to streamline language handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->