### PR TITLE
fix(frontend): narrow react-simple-maps projection type union

### DIFF
--- a/apps/frontend/src/types/react-simple-maps.d.ts
+++ b/apps/frontend/src/types/react-simple-maps.d.ts
@@ -21,7 +21,7 @@ declare module 'react-simple-maps' {
 
 	export const ComposableMap: ComponentType<{
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		projection?: string | any;
+		projection?: string | ((...args: any[]) => unknown);
 		projectionConfig?: ProjectionConfig;
 		width?: number;
 		height?: number;


### PR DESCRIPTION
## Summary
- `string | any` in `apps/frontend/src/types/react-simple-maps.d.ts` collapses to `any` and trips `@typescript-eslint/no-redundant-type-constituents`, causing `pnpm run check` to fail on a clean tree
- Narrow the projection prop to `string | ((...args: any[]) => unknown)` so the union stays meaningful while still covering the named-projection and custom-projection-function forms accepted by `react-simple-maps`

## Test plan
- [ ] `cd apps/frontend && pnpm run check` — lint and typecheck pass
- [ ] No runtime regression in the analytics world map (dashboard) that uses `ComposableMap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)