### PR TITLE
feat(url-shortener): serve short links on a dedicated redirect domain

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -43,3 +43,8 @@ STRIPE_PRO_PRICE_ID_ANNUAL=""
 # Google Web Risk API (URL safety check for redirect destinations).
 # Optional — leave empty to skip the check (fail-open). Create a key in Google Cloud → Web Risk API.
 GOOGLE_WEB_RISK_API_KEY=""
+
+# Dedicated redirect domain for short links (e.g. https://qrco.ly). Optional — when unset,
+# short links fall back to FRONTEND_URL. Isolating redirects on their own domain keeps a
+# later Safe-Browsing flag on a destination from touching the brand domain.
+SHORT_URL_BASE_URL=""

--- a/apps/backend/src/core/config/env.ts
+++ b/apps/backend/src/core/config/env.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 const server = z.object({
 	BASE_URL: z.url().default('http://localhost:5001'),
 	FRONTEND_URL: z.url().default('https://www.qrcodly.de'),
+	SHORT_URL_BASE_URL: z.url().optional(),
 	BACKEND_URL: z.url(),
 	DB_HOST: z.string(),
 	DB_USER: z.string(),

--- a/apps/backend/src/modules/url-shortener/config/constants.ts
+++ b/apps/backend/src/modules/url-shortener/config/constants.ts
@@ -1,6 +1,8 @@
 import { env } from '@/core/config/env';
 
-export const SHORT_BASE_URL = `${env.FRONTEND_URL}/u/`;
+const SHORT_URL_ORIGIN = env.SHORT_URL_BASE_URL ?? env.FRONTEND_URL;
+
+export const SHORT_BASE_URL = `${SHORT_URL_ORIGIN}/u/`;
 export const DYNAMIC_QR_BASE_URL = `${env.FRONTEND_URL}/api/dynamic-qr/`;
 
 export const DESKTOP_OS = [

--- a/apps/backend/src/modules/url-shortener/http/__tests__/reserve-short-url.test.ts
+++ b/apps/backend/src/modules/url-shortener/http/__tests__/reserve-short-url.test.ts
@@ -4,7 +4,7 @@ import {
 	assertReservedShortUrl,
 } from '@/tests/shared/assertions/short-url.assertions';
 import type { FastifyInstance } from 'fastify';
-import type { TShortUrlResponseDto } from '@shared/schemas';
+import type { TShortUrlResponseDto, TReservedShortUrlResponseDto } from '@shared/schemas';
 import { SHORT_URL_API_PATH } from './utils';
 
 describe('reserveShortUrl', () => {
@@ -37,6 +37,14 @@ describe('reserveShortUrl', () => {
 		assertShortUrlResponse(shortUrl, userId);
 		assertReservedShortUrl(shortUrl);
 		expect(shortUrl.shortCode).toHaveLength(5);
+	});
+
+	it('should include a fully-built shortUrl for the reserved code', async () => {
+		const response = await reserveShortUrlRequest(accessToken);
+		const shortUrl = JSON.parse(response.payload) as TReservedShortUrlResponseDto;
+
+		expect(shortUrl.shortUrl).toEqual(expect.any(String));
+		expect(shortUrl.shortUrl).toMatch(new RegExp(`/u/${shortUrl.shortCode}$`));
 	});
 
 	it('should return existing reserved short URL if user already has one', async () => {

--- a/apps/backend/src/modules/url-shortener/http/controller/short-url.controller.ts
+++ b/apps/backend/src/modules/url-shortener/http/controller/short-url.controller.ts
@@ -10,12 +10,14 @@ import {
 	AnalyticsResponseDto,
 	CreateShortUrlDto,
 	GetShortUrlQueryParamsSchema,
+	ReservedShortUrlResponseDto,
 	ShortUrlWithCustomDomainPaginatedResponseDto,
 	ShortUrlWithCustomDomainResponseDto,
 	TAnalyticsResponseDto,
 	TCreateShortUrlDto,
 	TGetShortUrlQueryParamsDto,
 	TGetShortUrlRequestQueryDto,
+	TReservedShortUrlResponseDto,
 	TShortUrlWithCustomDomainPaginatedResponseDto,
 	TShortUrlWithCustomDomainResponseDto,
 	TTrackScanDto,
@@ -24,6 +26,7 @@ import {
 	UpdateShortUrlDto,
 } from '@shared/schemas';
 import { GetReservedShortCodeUseCase } from '../../useCase/get-reserved-short-url.use-case';
+import { buildShortUrl } from '../../utils';
 import { UmamiAnalyticsService } from '../../service/umami-analytics.service';
 import { UpdateShortUrlUseCase } from '../../useCase/update-short-url.use-case';
 import { CreateShortUrlUseCase } from '../../useCase/create-short-url.use-case';
@@ -361,7 +364,7 @@ export class ShortUrlController extends AbstractController {
 
 	@Get('/reserved', {
 		responseSchema: {
-			200: ShortUrlWithCustomDomainResponseDto,
+			200: ReservedShortUrlResponseDto,
 			401: DEFAULT_ERROR_RESPONSES[401],
 			429: DEFAULT_ERROR_RESPONSES[429],
 		},
@@ -377,9 +380,13 @@ export class ShortUrlController extends AbstractController {
 	})
 	async reserveShortUrl(
 		request: IHttpRequest,
-	): Promise<IHttpResponse<TShortUrlWithCustomDomainResponseDto>> {
+	): Promise<IHttpResponse<TReservedShortUrlResponseDto>> {
 		const shortUrl = await this.getReservedShortCodeUseCase.execute(request.user.id);
-		return this.makeApiHttpResponse(200, ShortUrlWithCustomDomainResponseDto.parse(shortUrl));
+		const fullShortUrl = buildShortUrl(shortUrl.shortCode, shortUrl.customDomain?.domain ?? null);
+		return this.makeApiHttpResponse(
+			200,
+			ReservedShortUrlResponseDto.parse({ ...shortUrl, shortUrl: fullShortUrl }),
+		);
 	}
 
 	@Get('/:shortCode/analytics', {

--- a/apps/backend/src/modules/url-shortener/service/destination-url-safety.service.ts
+++ b/apps/backend/src/modules/url-shortener/service/destination-url-safety.service.ts
@@ -17,7 +17,7 @@ export class DestinationUrlSafetyService {
 		private readonly violationTracker: UrlSafetyViolationTracker,
 	) {
 		this.internalHostnames = new Set(
-			[env.FRONTEND_URL, env.BASE_URL, env.BACKEND_URL]
+			[env.FRONTEND_URL, env.BASE_URL, env.BACKEND_URL, env.SHORT_URL_BASE_URL]
 				.map((url) => this.safeHostname(url))
 				.filter((hostname): hostname is string => hostname !== null),
 		);
@@ -49,7 +49,8 @@ export class DestinationUrlSafetyService {
 		return hostname !== null && this.internalHostnames.has(hostname);
 	}
 
-	private safeHostname(url: string): string | null {
+	private safeHostname(url: string | undefined): string | null {
+		if (!url) return null;
 		try {
 			return new URL(url).hostname;
 		} catch {

--- a/apps/backend/src/modules/url-shortener/useCase/__tests__/update-short-url.use-case.test.ts
+++ b/apps/backend/src/modules/url-shortener/useCase/__tests__/update-short-url.use-case.test.ts
@@ -11,11 +11,14 @@ import type { TUpdateShortUrlDto } from '@shared/schemas';
 import type { TQrCode } from '@shared/schemas';
 import { QrCodeNotFoundError } from '@/modules/qr-code/error/http/qr-code-not-found.error';
 import { RedirectLoopError } from '../../error/http/redirect-loop.error';
-import { buildShortUrl } from '../../utils';
+import { isSelfReferencingShortUrl } from '../../utils';
 import type { DestinationUrlSafetyService } from '../../service/destination-url-safety.service';
 
 jest.mock('../../utils', () => ({
-	buildShortUrl: jest.fn((shortCode: string) => `https://short.url/${shortCode}`),
+	isSelfReferencingShortUrl: jest.fn(
+		(destinationUrl: string | null | undefined, shortCode: string) =>
+			destinationUrl === `https://short.url/${shortCode}`,
+	),
 }));
 
 describe('UpdateShortUrlUseCase', () => {
@@ -252,7 +255,7 @@ describe('UpdateShortUrlUseCase', () => {
 			).resolves.toBeDefined();
 		});
 
-		it('should build short URL correctly using buildShortUrl()', async () => {
+		it('should check self-reference via isSelfReferencingShortUrl()', async () => {
 			const updateDto: TUpdateShortUrlDto = {
 				destinationUrl: 'https://short.url/ABC12',
 			};
@@ -275,7 +278,10 @@ describe('UpdateShortUrlUseCase', () => {
 				RedirectLoopError,
 			);
 
-			expect(buildShortUrl).toHaveBeenCalledWith(mockShortUrl.shortCode);
+			expect(isSelfReferencingShortUrl).toHaveBeenCalledWith(
+				'https://short.url/ABC12',
+				mockShortUrl.shortCode,
+			);
 		});
 
 		it('should throw QrCodeNotFoundError when linkedQrCodeId provided but QR code does not exist', async () => {

--- a/apps/backend/src/modules/url-shortener/useCase/update-short-url.use-case.ts
+++ b/apps/backend/src/modules/url-shortener/useCase/update-short-url.use-case.ts
@@ -7,7 +7,7 @@ import { TShortUrl } from '../domain/entities/short-url.entity';
 import QrCodeRepository from '@/modules/qr-code/domain/repository/qr-code.repository';
 import { QrCodeNotFoundError } from '@/modules/qr-code/error/http/qr-code-not-found.error';
 import { RedirectLoopError } from '../error/http/redirect-loop.error';
-import { buildShortUrl } from '../utils';
+import { isSelfReferencingShortUrl } from '../utils';
 import { CustomDomainValidationService } from '@/modules/custom-domain/service/custom-domain-validation.service';
 import { DestinationUrlSafetyService } from '../service/destination-url-safety.service';
 
@@ -64,8 +64,9 @@ export class UpdateShortUrlUseCase implements IBaseUseCase {
 			updatedAt: new Date(),
 		};
 
-		// prevent linking if qr code points to same url to avoid redirect loops
-		if (updatesDto?.destinationUrl === buildShortUrl(shortUrl.shortCode)) {
+		// prevent linking a destination that points back at this short URL (redirect loop) —
+		// matched on any host we serve it on: redirect domain, legacy brand domain, or custom domain
+		if (isSelfReferencingShortUrl(updatesDto?.destinationUrl, shortUrl.shortCode)) {
 			throw new RedirectLoopError();
 		}
 

--- a/apps/backend/src/modules/url-shortener/utils/__tests__/index.test.ts
+++ b/apps/backend/src/modules/url-shortener/utils/__tests__/index.test.ts
@@ -1,0 +1,50 @@
+import { isSelfReferencingShortUrl } from '../index';
+
+// Control both recognized system hosts so we can assert the redirect-domain split behaviour.
+jest.mock('@/core/config/env', () => ({
+	env: {
+		FRONTEND_URL: 'https://www.qrcodly.de',
+		SHORT_URL_BASE_URL: 'https://qrco.ly',
+	},
+}));
+
+describe('isSelfReferencingShortUrl', () => {
+	const code = 'abc12';
+
+	it('matches the dedicated redirect domain', () => {
+		expect(isSelfReferencingShortUrl('https://qrco.ly/u/abc12', code)).toBe(true);
+	});
+
+	it('matches the legacy brand domain (regression: old-domain self-reference)', () => {
+		expect(isSelfReferencingShortUrl('https://www.qrcodly.de/u/abc12', code)).toBe(true);
+		expect(isSelfReferencingShortUrl('https://qrcodly.de/u/abc12', code)).toBe(true);
+	});
+
+	it('matches a provided custom-domain host', () => {
+		expect(
+			isSelfReferencingShortUrl('https://links.acme.com/u/abc12', code, 'links.acme.com'),
+		).toBe(true);
+	});
+
+	it('ignores a different short code on a recognized host', () => {
+		expect(isSelfReferencingShortUrl('https://qrco.ly/u/other', code)).toBe(false);
+	});
+
+	it('ignores an unrecognized host', () => {
+		expect(isSelfReferencingShortUrl('https://evil.example/u/abc12', code)).toBe(false);
+	});
+
+	it('ignores a different path on a recognized host', () => {
+		expect(isSelfReferencingShortUrl('https://qrco.ly/pricing', code)).toBe(false);
+	});
+
+	it('tolerates a trailing slash', () => {
+		expect(isSelfReferencingShortUrl('https://qrco.ly/u/abc12/', code)).toBe(true);
+	});
+
+	it('returns false for empty or unparseable input', () => {
+		expect(isSelfReferencingShortUrl(null, code)).toBe(false);
+		expect(isSelfReferencingShortUrl(undefined, code)).toBe(false);
+		expect(isSelfReferencingShortUrl('not-a-url', code)).toBe(false);
+	});
+});

--- a/apps/backend/src/modules/url-shortener/utils/index.ts
+++ b/apps/backend/src/modules/url-shortener/utils/index.ts
@@ -1,14 +1,55 @@
 import { SHORT_BASE_URL } from '../config/constants';
+import { env } from '@/core/config/env';
 
 /**
  * Build the full short URL with the given code.
  * @param code - The short code
  * @param customDomainHost - Optional custom domain host (e.g., "my.custom.domain")
- * @returns The full short URL (e.g., "https://qrcodly.de/u/abc12" or "https://my.custom.domain/u/abc12")
+ * @returns The full short URL (e.g., "https://qrco.ly/u/abc12" or "https://my.custom.domain/u/abc12")
  */
 export function buildShortUrl(code: string, customDomainHost?: string | null): string {
 	if (customDomainHost) {
 		return `https://${customDomainHost}/u/${code}`;
 	}
 	return `${SHORT_BASE_URL}${code}`;
+}
+
+function toHost(url: string | null | undefined): string | null {
+	if (!url) return null;
+	try {
+		return new URL(url).hostname.replace(/^www\./, '');
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * True if `destinationUrl` points back at this short URL's own `/u/<code>` path on any host we
+ * serve redirects on — the dedicated redirect domain (SHORT_URL_BASE_URL), the legacy brand domain
+ * (FRONTEND_URL), or the short URL's custom domain — which would create a redirect loop.
+ * Host-set based rather than exact-string equality, so it stays correct across the domain split.
+ * Best-effort: unparseable destinations return false.
+ */
+export function isSelfReferencingShortUrl(
+	destinationUrl: string | null | undefined,
+	shortCode: string,
+	customDomainHost?: string | null,
+): boolean {
+	if (!destinationUrl) return false;
+	let parsed: URL;
+	try {
+		parsed = new URL(destinationUrl);
+	} catch {
+		return false;
+	}
+	if (parsed.pathname.replace(/\/+$/, '') !== `/u/${shortCode}`) return false;
+
+	const hosts = new Set<string>();
+	for (const url of [env.SHORT_URL_BASE_URL, env.FRONTEND_URL]) {
+		const host = toHost(url);
+		if (host) hosts.add(host);
+	}
+	if (customDomainHost) hosts.add(customDomainHost.replace(/^www\./, ''));
+
+	return hosts.has(parsed.hostname.replace(/^www\./, ''));
 }

--- a/apps/browser-extension/src/shims/env.ts
+++ b/apps/browser-extension/src/shims/env.ts
@@ -1,6 +1,8 @@
 // Shim for @/env — replaces @t3-oss/env-nextjs with plain Vite env vars
 export const env = {
 	NEXT_PUBLIC_FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL ?? 'https://www.qrcodly.de',
+	// Left undefined when unset so the shared builder falls back to FRONTEND_URL (web-app semantics).
+	NEXT_PUBLIC_SHORT_URL_DOMAIN: import.meta.env.VITE_SHORT_URL_DOMAIN,
 	NEXT_PUBLIC_API_URL: import.meta.env.VITE_API_URL ?? 'https://api.qrcodly.de/api/v1',
 	NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
 	NEXT_PUBLIC_POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY ?? '',

--- a/apps/desktop/src/renderer/shims/env.ts
+++ b/apps/desktop/src/renderer/shims/env.ts
@@ -1,6 +1,8 @@
 // Shim for @/env — replaces @t3-oss/env-nextjs with plain Vite env vars
 export const env = {
 	NEXT_PUBLIC_FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL ?? 'https://www.qrcodly.de',
+	// Left undefined when unset so the shared builder falls back to FRONTEND_URL (web-app semantics).
+	NEXT_PUBLIC_SHORT_URL_DOMAIN: import.meta.env.VITE_SHORT_URL_DOMAIN,
 	NEXT_PUBLIC_API_URL: import.meta.env.VITE_API_URL ?? 'https://api.qrcodly.de',
 	NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: import.meta.env.VITE_CLERK_PUBLISHABLE_KEY ?? '',
 	NEXT_PUBLIC_POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY ?? '',

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
 	readonly VITE_FRONTEND_URL: string;
+	readonly VITE_SHORT_URL_DOMAIN?: string;
 	readonly VITE_API_URL: string;
 	readonly VITE_CLERK_PUBLISHABLE_KEY: string;
 	readonly VITE_POSTHOG_KEY: string;

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -19,3 +19,8 @@ NEXT_PUBLIC_POSTHOG_HOST=""
 
 # Internal API auth (shared secret between frontend and backend)
 INTERNAL_API_SECRET=""
+
+# Dedicated redirect domain for short links (e.g. https://qrco.ly). Optional — when unset,
+# short links fall back to NEXT_PUBLIC_FRONTEND_URL. Must point at this frontend deployment;
+# only /u/<code> is served there, every other path 301s to the brand domain.
+NEXT_PUBLIC_SHORT_URL_DOMAIN=""

--- a/apps/frontend/src/components/FeatureSlider.tsx
+++ b/apps/frontend/src/components/FeatureSlider.tsx
@@ -47,7 +47,6 @@ export function FeatureSlider() {
 			icon: <LinkIcon className="h-9 w-9 sm:h-11 sm:w-11" />,
 			headlineKey: 'shortUrlFeature.headline',
 			subHeadlineKey: 'shortUrlFeature.subHeadline',
-			badge: tGeneral('newBadge'),
 			actionLabel: t('shortUrlFeature.actionLabel'),
 			actionHref: '/dashboard/short-urls',
 			authOnly: true,

--- a/apps/frontend/src/env.js
+++ b/apps/frontend/src/env.js
@@ -21,6 +21,7 @@ export const env = createEnv({
 	 */
 	client: {
 		NEXT_PUBLIC_FRONTEND_URL: z.string().url(),
+		NEXT_PUBLIC_SHORT_URL_DOMAIN: z.string().url().optional(),
 		NEXT_PUBLIC_API_URL: z.string().url(),
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string(),
 		NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
@@ -46,6 +47,7 @@ export const env = createEnv({
 		CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
 
 		NEXT_PUBLIC_FRONTEND_URL: process.env.NEXT_PUBLIC_FRONTEND_URL,
+		NEXT_PUBLIC_SHORT_URL_DOMAIN: process.env.NEXT_PUBLIC_SHORT_URL_DOMAIN,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -16,11 +16,12 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Extracts the system domain from NEXT_PUBLIC_FRONTEND_URL (e.g., "qrcodly.de" from "https://www.qrcodly.de").
+ * Extracts the system short-link domain (e.g., "qrco.ly"). Prefers the dedicated redirect
+ * domain (NEXT_PUBLIC_SHORT_URL_DOMAIN) and falls back to NEXT_PUBLIC_FRONTEND_URL when unset.
  */
 export function getSystemDomain(): string {
 	try {
-		const url = new URL(env.NEXT_PUBLIC_FRONTEND_URL);
+		const url = new URL(env.NEXT_PUBLIC_SHORT_URL_DOMAIN ?? env.NEXT_PUBLIC_FRONTEND_URL);
 		return url.hostname.replace(/^www\./, '');
 	} catch {
 		return 'qrcodly.de';
@@ -51,8 +52,10 @@ export function createLinkFromShortUrl(
 	if (customDomain) {
 		url = `https://${customDomain.domain}/u/${shortCode}`;
 	} else {
-		// System domain uses /u/ prefix (e.g., qrcodly.de/u/abc12)
-		url = `${env.NEXT_PUBLIC_FRONTEND_URL}/u/${shortCode}`;
+		// System short links live on the dedicated redirect domain (falls back to the app
+		// domain), using the /u/ prefix (e.g. qrco.ly/u/abc12).
+		const systemOrigin = env.NEXT_PUBLIC_SHORT_URL_DOMAIN ?? env.NEXT_PUBLIC_FRONTEND_URL;
+		url = `${systemOrigin}/u/${shortCode}`;
 	}
 
 	if (!short) return url;

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -4,6 +4,7 @@ import { type NextFetchEvent, type NextRequest, NextResponse } from 'next/server
 import { processAnalyticsAndRedirect } from './middlewares/process-analytics-and-redirect.middleware';
 import createMiddleware from 'next-intl/middleware';
 import { routing, SUPPORTED_LANGUAGES } from './i18n/routing';
+import { env } from '@/env';
 
 const isProtectedRoute = createRouteMatcher([
 	'(.*)/dashboard(.*)',
@@ -21,6 +22,32 @@ const localePrefixedNonTranslatedRoute = new RegExp(`^/(${localePrefix})/(docs)(
 // Short URL scan pattern — system 5-char codes or 3–50-char custom slugs.
 // Allowed: lowercase letters, digits, hyphens (no leading/trailing hyphen).
 const scanPattern = /^\/u\/(?:[a-z0-9]{5}|[a-z0-9][a-z0-9-]{1,48}[a-z0-9])$/;
+
+/** Bare hostname (no port, no leading www) of a configured URL, or null if unset/invalid. */
+function normalizeHost(urlString: string | undefined): string | null {
+	if (!urlString) return null;
+	try {
+		return new URL(urlString).hostname.replace(/^www\./, '');
+	} catch {
+		return null;
+	}
+}
+
+// The dedicated redirect domain — only when configured AND distinct from the brand domain.
+// On this host we serve short-URL redirects (/u/<code>) and nothing else: every other path
+// is 301'd to the brand domain, so no app/marketing content lives on the sacrificial domain
+// and a Safe-Browsing flag there can never touch the brand.
+const brandHost = normalizeHost(env.NEXT_PUBLIC_FRONTEND_URL);
+const shortUrlHost = normalizeHost(env.NEXT_PUBLIC_SHORT_URL_DOMAIN);
+const redirectOnlyHost = shortUrlHost && shortUrlHost !== brandHost ? shortUrlHost : null;
+
+/** Run the scan/redirect flow and tag the response noindex (shared by both hosts). */
+function scanResponse(req: NextRequest) {
+	return processAnalyticsAndRedirect(req).then((response) => {
+		response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
+		return response;
+	});
+}
 
 const clerkHandler = clerkMiddleware(async (auth, req, event) => {
 	const pathname = new URL(req.url).pathname;
@@ -62,21 +89,29 @@ const clerkHandler = clerkMiddleware(async (auth, req, event) => {
 });
 
 export default function middleware(req: NextRequest, event: NextFetchEvent) {
-	const pathname = new URL(req.url).pathname;
+	const { pathname, search } = new URL(req.url);
 
 	// .well-known paths bypass all middleware (MCP registry auth, etc.)
 	if (pathname.startsWith('/.well-known/')) {
 		return NextResponse.next();
 	}
 
+	// Dedicated redirect domain: serve only short-URL redirects; 301 everything else to the
+	// brand domain (same path) so the sacrificial domain never renders app/marketing content.
+	// (_next/static assets bypass middleware via the matcher, so the /disabled page still works.)
+	if (redirectOnlyHost) {
+		const reqHost = ((req.headers.get('host') ?? '').split(':')[0] ?? '').replace(/^www\./, '');
+		if (reqHost === redirectOnlyHost) {
+			if (scanPattern.test(pathname)) return scanResponse(req);
+			return NextResponse.redirect(new URL(pathname + search, env.NEXT_PUBLIC_FRONTEND_URL), 301);
+		}
+	}
+
 	// Scan routes bypass Clerk entirely — no auth needed.
 	// Tag /u/* responses noindex so phishing/abuse short URLs cannot be picked
 	// up by search engines even when linked externally (stronger than robots.txt).
 	if (scanPattern.test(pathname)) {
-		return processAnalyticsAndRedirect(req).then((response) => {
-			response.headers.set('X-Robots-Tag', 'noindex, nofollow, noarchive');
-			return response;
-		});
+		return scanResponse(req);
 	}
 
 	return clerkHandler(req, event);

--- a/apps/integrations/indesign/src/lib/api-client.ts
+++ b/apps/integrations/indesign/src/lib/api-client.ts
@@ -94,7 +94,7 @@ export class QrcodlyApi {
 		return this.request('/config-template');
 	}
 
-	getReservedShortCode(): Promise<{ shortCode: string }> {
+	getReservedShortCode(): Promise<{ shortCode: string; shortUrl: string }> {
 		return this.request('/short-url/reserved');
 	}
 

--- a/apps/integrations/indesign/src/screens/CreateScreen.tsx
+++ b/apps/integrations/indesign/src/screens/CreateScreen.tsx
@@ -14,8 +14,6 @@ type Props = {
 
 type ContentType = 'url' | 'text';
 
-const SHORT_URL_BASE = 'https://qrcodly.de/u/';
-
 export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 	const api = useMemo(() => new QrcodlyApi(apiKey), [apiKey]);
 
@@ -26,14 +24,15 @@ export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 	const [name, setName] = useState('');
 	const [isDynamic, setIsDynamic] = useState(true);
 	const [reservedShortCode, setReservedShortCode] = useState<string | null>(null);
+	const [reservedShortUrl, setReservedShortUrl] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
 	const selectedTemplate = templates.find((t) => t.id === templateId);
 	const trimmed = value.trim();
 	const livePayload = trimmed
-		? contentType === 'url' && isDynamic && reservedShortCode
-			? `${SHORT_URL_BASE}${reservedShortCode}`
+		? contentType === 'url' && isDynamic && reservedShortUrl
+			? reservedShortUrl
 			: trimmed
 		: null;
 
@@ -55,6 +54,7 @@ export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 	useEffect(() => {
 		if (contentType !== 'url' || !isDynamic) {
 			setReservedShortCode(null);
+			setReservedShortUrl(null);
 			return;
 		}
 		if (reservedShortCode) return;
@@ -62,7 +62,10 @@ export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 		void api
 			.getReservedShortCode()
 			.then((res) => {
-				if (!cancelled) setReservedShortCode(res.shortCode);
+				if (!cancelled) {
+					setReservedShortCode(res.shortCode);
+					setReservedShortUrl(res.shortUrl);
+				}
 			})
 			.catch(() => {
 				/* non-fatal — render without it */
@@ -132,7 +135,7 @@ export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 		onDone();
 	};
 
-	const showShortUrlHint = contentType === 'url' && isDynamic && reservedShortCode;
+	const showShortUrlHint = contentType === 'url' && isDynamic && reservedShortUrl;
 
 	return (
 		<div className="app">
@@ -192,9 +195,7 @@ export function CreateScreen({ apiKey, onDone, onCancel }: Props) {
 				</label>
 			)}
 
-			{showShortUrlHint && (
-				<div className="short-url-display">{`${SHORT_URL_BASE}${reservedShortCode}`}</div>
-			)}
+			{showShortUrlHint && <div className="short-url-display">{reservedShortUrl}</div>}
 
 			{templates.length > 0 && (
 				<div className="field">

--- a/packages/shared/src/dtos/url-shortener/ReservedShortUrlResponseDto.ts
+++ b/packages/shared/src/dtos/url-shortener/ReservedShortUrlResponseDto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { ShortUrlWithCustomDomainResponseDto } from './ShortUrlResponseDto';
+
+/**
+ * Reserved short URL response: the standard short URL payload plus the fully-built short URL
+ * string (the dedicated redirect domain or the short URL's custom domain). This lets clients that
+ * render a preview before the destination is known — e.g. the InDesign plugin — use the
+ * server-authoritative short URL instead of hardcoding a domain.
+ */
+export const ReservedShortUrlResponseDto = ShortUrlWithCustomDomainResponseDto.extend({
+	shortUrl: z
+		.string()
+		.describe('Fully-built short URL for the reserved code (redirect domain or custom domain).'),
+});
+export type TReservedShortUrlResponseDto = z.infer<typeof ReservedShortUrlResponseDto>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from './dtos/qr-code-templates/ConfigTemplateRequestParamsDto';
 
 export * from './dtos/url-shortener/ShortUrlRequestParamsDto';
 export * from './dtos/url-shortener/ShortUrlResponseDto';
+export * from './dtos/url-shortener/ReservedShortUrlResponseDto';
 export * from './dtos/url-shortener/ShortUrlPaginatedResponseDto';
 export * from './dtos/url-shortener/ShortUrlQueryParamsDto';
 export * from './dtos/url-shortener/CreateShortUrlDto';


### PR DESCRIPTION
## Description

Short-link redirects previously ran on the brand domain (`FRONTEND_URL`), so a destination that Google Safe Browsing flags **after** creation could taint the brand domain's reputation — worst case, getting already-printed QR codes blocked. This PR introduces an optional **dedicated redirect domain** that isolates that blast radius: short links live on their own sacrificial domain, and the brand/app domain stays uninvolved for new links.

Both env vars are optional and fall back to the brand domain, so **this is a no-op until the redirect domain is configured** — safe to merge/deploy before the domain even exists. Existing QR codes keep working on `qrcodly.de` because their encoded value is frozen in `qrCodeData` at creation.

### What changed
- **Backend**: optional `SHORT_URL_BASE_URL`; `SHORT_BASE_URL` / `buildShortUrl` build on it; added to the internal-hostname set for redirect-loop protection.
- **Frontend**: optional `NEXT_PUBLIC_SHORT_URL_DOMAIN`; `getSystemDomain` + `createLinkFromShortUrl` use it; `proxy.ts` serves **only** `/u/<code>` on the redirect host and 301s every other path to the brand domain (no app/marketing content on the sacrificial domain).
- **Desktop + browser-extension**: map `VITE_SHORT_URL_DOMAIN` in the env shims (falls back to `FRONTEND_URL` when unset).
- **InDesign**: the reserved-code endpoint now returns the fully-built `shortUrl` (new `ReservedShortUrlResponseDto`); the plugin preview no longer hardcodes the domain and now respects custom domains.
- **Redirect-loop guard** hardened (`isSelfReferencingShortUrl`): matches `/u/<code>` against any recognized host (redirect domain, legacy brand domain, custom domain) instead of exact-string equality.
- **UI**: dropped the "new" badge from the short-URL feature slide.
- **Tests**: cover `isSelfReferencingShortUrl` and the reserved `shortUrl` field.

### Deploy notes
- Backend: set `SHORT_URL_BASE_URL=https://<redirect-domain>`.
- Frontend: set `NEXT_PUBLIC_SHORT_URL_DOMAIN=https://<redirect-domain>` and point the domain at this deployment (Coolify/Traefik auto-TLS).
- Desktop/extension: set `VITE_SHORT_URL_DOMAIN` in their Vite build env — `NEXT_PUBLIC_*` is build-time-inlined, so **rebuild** (not just restart).
- Dynamic-QR landing pages (`/api/dynamic-qr/…`) intentionally stay on the brand domain for now (different risk profile — they render real content).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style.
- [x] I have commented on my code where necessary.
- [x] I have updated the documentation where relevant (`.env.example` for backend + frontend).
- [x] I have added tests for the changes.
- [ ] All new and existing tests pass. — typecheck + lint are green across backend, frontend, InDesign, desktop and browser-extension; the backend Jest suite was **not** run in the working environment (missing local secrets), so please run `pnpm run pr:precheck` before merge.

## Related Issues

_None._

## Screenshots (if applicable)

N/A — redirect-domain routing and env plumbing; no user-facing visual change beyond the removed feature-slide badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable short-link redirect domains with automatic fallback to the main website domain.
  * Reserved short-link responses now include the complete URL.
  * Updated desktop, browser extension, frontend, and InDesign integrations to support configurable short-link domains.
  * Added redirect-domain handling that preserves paths and query parameters.

* **Bug Fixes**
  * Improved redirect-loop prevention across configured and custom domains.
  * Added safer handling for invalid or missing destination URLs.

* **Tests**
  * Expanded coverage for reserved URLs, redirect loops, and custom domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->