### PR TITLE
fix(url-shortener): geolocate scans by the visitor IP, not the backend

### DIFF
--- a/apps/backend/src/modules/url-shortener/service/__tests__/umami-analytics.service.test.ts
+++ b/apps/backend/src/modules/url-shortener/service/__tests__/umami-analytics.service.test.ts
@@ -131,6 +131,44 @@ describe('UmamiAnalyticsService', () => {
 		});
 	});
 
+	describe('sendEvent', () => {
+		const payload = {
+			url: 'https://qrco.ly/u/abc12',
+			userAgent: 'Mozilla/5.0',
+			hostname: 'qrco.ly',
+			language: 'en-GB',
+			referrer: '',
+			screen: '',
+			deviceType: 'mobile',
+			browserName: 'chrome',
+			ip: '203.0.113.7',
+		};
+
+		it('forwards the scanner IP via X-Client-Real-IP so Umami geolocates the visitor', async () => {
+			mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+			await service.sendEvent(payload);
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'https://umami.example.com/api/send',
+				expect.objectContaining({
+					method: 'POST',
+					headers: expect.objectContaining({
+						'User-Agent': payload.userAgent,
+						'X-Client-Real-IP': payload.ip,
+					}),
+				}),
+			);
+		});
+
+		it('does not throw and logs when the Umami request fails', async () => {
+			mockFetch.mockRejectedValue(new Error('network'));
+
+			await expect(service.sendEvent(payload)).resolves.toBeUndefined();
+			expect(mockLogger.error).toHaveBeenCalledWith('error.umamiApi.sendEvent', expect.anything());
+		});
+	});
+
 	describe('getViewsForEndpoint', () => {
 		beforeEach(() => {
 			// Mock successful auth

--- a/apps/backend/src/modules/url-shortener/service/umami-analytics.service.ts
+++ b/apps/backend/src/modules/url-shortener/service/umami-analytics.service.ts
@@ -143,6 +143,7 @@ export class UmamiAnalyticsService {
 				headers: {
 					'Content-Type': 'application/json',
 					'User-Agent': payload.userAgent,
+					'X-Client-Real-IP': payload.ip,
 				},
 				body: JSON.stringify({
 					type: 'event',


### PR DESCRIPTION
## Description

Scan analytics showed the **wrong country** — a constant location (the backend server's) rather than the visitor's.

**Root cause:** scan events are sent to Umami **server-side** (frontend middleware → backend → Umami `/api/send`). The scanner's IP was passed only in the JSON body as `payload.ip`, which most Umami versions ignore for geolocation — Umami derives location from the request's IP headers. Since the request originates from our backend and no visitor-IP header was forwarded, Umami geolocated **our backend's IP**, so every scan resolved to the server's country. (Umami has no language→country fallback, so this was not an `Accept-Language` issue.)

**Fix:** forward the scanner IP to Umami in an `X-Client-Real-IP` header. A custom header (rather than `X-Forwarded-For`) is used deliberately so it survives untouched through any reverse proxy sitting in front of Umami.

### What changed
- `umami-analytics.service.ts` — `sendEvent` now sends `X-Client-Real-IP: <scanner-ip>`.
- `umami-analytics.service.test.ts` — added `sendEvent` coverage (header is forwarded; failure path stays fail-open).

### Required config (ops)
Umami must be configured to read that header:
- `CLIENT_IP_HEADER=x-client-real-ip`
- (`SKIP_LOCATION_HEADERS=1` only needed if a CDN/proxy in front of Umami injects a location header such as `cf-ipcountry`; not required for a direct/DNS-only Umami host.)

Without the env var this change is a no-op; with it, scans geolocate to the visitor's real location.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style.
- [x] I have commented on my code where necessary.
- [ ] I have updated the documentation where relevant. (n/a — behaviour fix; ops env documented above)
- [x] I have added tests for the changes.
- [ ] All new and existing tests pass. — backend typecheck + lint are green; the Jest suite was not run in the working environment (missing local secrets), so please run `pnpm run pr:precheck`.

## Related Issues

_None._

## Screenshots (if applicable)

N/A — server-side analytics header change; verify by scanning from a known location and checking the country in Umami after the env var is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics events now forward the scanner’s IP address to improve event attribution.
  * Event delivery failures are handled gracefully without interrupting the surrounding workflow.

* **Tests**
  * Added coverage for IP and user-agent forwarding.
  * Added verification for resilient error handling during analytics requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->